### PR TITLE
Fix corporate mail field naming

### DIFF
--- a/bot/DAL/create_dal.py
+++ b/bot/DAL/create_dal.py
@@ -25,9 +25,9 @@ class CreateDAL:
         return new_user
     
     async def create_company(self, name : str, password : str, phone : str, email : str, add_info : str, website : str, sf_id : str) -> Company:
-        new_company = Company(company_name=name, 
+        new_company = Company(company_name=name,
                               company_hashed_password=password,
-                              company_corporeate_mail=email,
+                              company_corporate_mail=email,
                               company_phone=phone,
                               company_website=website,
                               company_additional_info=add_info,

--- a/bot/alembic/versions/f681f95fd4f5_companies_fix.py
+++ b/bot/alembic/versions/f681f95fd4f5_companies_fix.py
@@ -24,7 +24,7 @@ def upgrade() -> None:
     sa.Column('company_id', sa.UUID(), nullable=False),
     sa.Column('company_name', sa.String(), nullable=False),
     sa.Column('company_hashed_password', sa.String(), nullable=False),
-    sa.Column('company_corporeate_mail', sa.String(), nullable=True),
+    sa.Column('company_corporate_mail', sa.String(), nullable=True),
     sa.Column('company_phone', sa.String(), nullable=True),
     sa.Column('company_website', sa.String(), nullable=True),
     sa.Column('company_additional_info', sa.Text(), nullable=True),

--- a/bot/database/models.py
+++ b/bot/database/models.py
@@ -11,7 +11,7 @@ class Company(Base):
     company_name = Column(String, nullable=False, unique=True)
     company_sf_id = Column(String, nullable=False, unique=True)
     company_hashed_password = Column(String, nullable=False)
-    company_corporeate_mail = Column(String, nullable=True)
+    company_corporate_mail = Column(String, nullable=True)
     company_phone = Column(String, nullable=True)
     company_website = Column(String, nullable=True)
     company_additional_info = Column(Text, nullable=True)


### PR DESCRIPTION
## Summary
- correct `company_corporate_mail` spelling in models
- adjust DAL creation logic to use new field
- update Alembic migration for new column name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ec60ae60832e8675892d1512c32d