### PR TITLE
Add AsyncDict tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,5 @@ typing_extensions==4.12.2
 urllib3==2.2.2
 yarl==1.9.7
 zeep==4.2.1
+
+pytest==8.3.5

--- a/tests/test_async_dict.py
+++ b/tests/test_async_dict.py
@@ -1,0 +1,47 @@
+import asyncio
+from bot.services.async_dict import AsyncDict
+
+
+def test_set_and_get():
+    d = AsyncDict()
+
+    async def run():
+        await d.set('foo', 'bar')
+        return await d.get('foo')
+
+    result = asyncio.run(run())
+    assert result == 'bar'
+
+
+def test_get_missing_key():
+    d = AsyncDict()
+
+    async def run():
+        return await d.get('missing')
+
+    result = asyncio.run(run())
+    assert result is None
+
+
+def test_delete():
+    d = AsyncDict()
+
+    async def run():
+        await d.set('key', 'value')
+        await d.delete('key')
+        return await d.get('key')
+
+    result = asyncio.run(run())
+    assert result is None
+
+
+def test_keys():
+    d = AsyncDict()
+
+    async def run():
+        await d.set('a', 1)
+        await d.set('b', 2)
+        return await d.keys()
+
+    keys = asyncio.run(run())
+    assert set(keys) == {'a', 'b'}


### PR DESCRIPTION
## Summary
- add pytest to requirements
- write async tests for AsyncDict covering set/get/delete/keys

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ec7fe19c832eb835f73046cece61