### PR TITLE
Fix callback comment typo

### DIFF
--- a/bot/routes/admin_route.py
+++ b/bot/routes/admin_route.py
@@ -133,7 +133,7 @@ async def admin_creating_org_final(msg: types.Message, state: FSMContext) -> Non
         )
     await msg.answer(message_text, reply_markup=keyboard.admin_menu_keyboard)
 
-#! callback querries 
+#! callback queries 
 
 
 #! functions

--- a/bot/routes/change_user_info_route.py
+++ b/bot/routes/change_user_info_route.py
@@ -42,7 +42,7 @@ async def handle_username_change(msg: types.Message, state: FSMContext) -> None:
     await msg.answer(f"Ваше новое имя <b>{new_name}</b>", reply_markup=keyboard.main_menu_keyboard)
     await state.set_state(MainUsage.ticket_acsess)
       
-#! callback querries 
+#! callback queries 
 
 @edit_router.callback_query(lambda c: c.data.startswith('company_'), MainUsage.changing_org)
 async def company_changing_callback_querry(callback_query: types.CallbackQuery, state: FSMContext) -> None:

--- a/bot/routes/ticket_route.py
+++ b/bot/routes/ticket_route.py
@@ -56,7 +56,7 @@ async def ticker_proc(msg: types.Message, state: FSMContext) -> None:
 
 #! handlers
 
-#! callback querries 
+#! callback queries 
 
 #! functions
             


### PR DESCRIPTION
## Summary
- correct typos in comments for callback handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ec7f1034832e861c0ea3b851209d